### PR TITLE
Jokropp patch python version3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "numpy", "Cython==0.29.32"]
+requires = ["setuptools", "numpy", "Cython"]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from setuptools import setup
-from distutils.extension import Extension
+from setuptools import setup, Extension
 
 try:
     from Cython.Build import cythonize


### PR DESCRIPTION
Fixes the cython version to achieve compatibility with python 3.12

Also removes distutils from setup.py, as it is deprecated since python 3.10 and can result in errors